### PR TITLE
fix: preserve --surface flag when resolving workspace

### DIFF
--- a/bin/cmux-read
+++ b/bin/cmux-read
@@ -31,7 +31,7 @@ while [[ $i -lt ${#ARGS[@]} ]]; do
     if [[ "$arg" == "--surface" ]]; then
         i=$((i + 1))
         ws=$(_resolve_surface "${ARGS[$i]}")
-        NEW_ARGS+=("--workspace" "$ws")
+        NEW_ARGS+=("--workspace" "$ws" "--surface" "${ARGS[$i]}")
     else
         NEW_ARGS+=("$arg")
     fi

--- a/bin/cmux-send
+++ b/bin/cmux-send
@@ -31,7 +31,7 @@ while [[ $i -lt ${#ARGS[@]} ]]; do
     if [[ "$arg" == "--surface" ]]; then
         i=$((i + 1))
         ws=$(_resolve_surface "${ARGS[$i]}")
-        NEW_ARGS+=("--workspace" "$ws")
+        NEW_ARGS+=("--workspace" "$ws" "--surface" "${ARGS[$i]}")
     else
         NEW_ARGS+=("$arg")
     fi

--- a/bin/cmux-send-key
+++ b/bin/cmux-send-key
@@ -31,7 +31,7 @@ while [[ $i -lt ${#ARGS[@]} ]]; do
     if [[ "$arg" == "--surface" ]]; then
         i=$((i + 1))
         ws=$(_resolve_surface "${ARGS[$i]}")
-        NEW_ARGS+=("--workspace" "$ws")
+        NEW_ARGS+=("--workspace" "$ws" "--surface" "${ARGS[$i]}")
     else
         NEW_ARGS+=("$arg")
     fi


### PR DESCRIPTION
## Summary

The `cmux-send`, `cmux-send-key`, and `cmux-read` wrappers translate `--surface` into `--workspace`, but they discard the original `--surface` flag before invoking `cmux`. As a result, `cmux` falls back to the workspace's default surface, and any non-default surface in the same workspace is unreachable through the wrappers.

This PR keeps `--surface` alongside the resolved `--workspace` so `cmux` targets the exact surface specified by the caller.

## Reproduction

```console
$ SURF=$(cmux new-split right | awk '{print $2}')  # e.g. surface:5
$ cmux-send --surface $SURF 'echo hello\n'
OK surface:1 workspace:1   # ← sent to surface:1 instead of surface:5
```

With this fix:

```console
$ cmux-send --surface $SURF 'echo hello\n'
OK surface:5 workspace:1   # ← correctly routed to the requested surface
```

## Change

Each wrapper used to build its argument list like this:

```bash
NEW_ARGS+=("--workspace" "$ws")
```

This PR changes that to:

```bash
NEW_ARGS+=("--workspace" "$ws" "--surface" "${ARGS[$i]}")
```

## Tested

- `cmux-send --surface surface:N` now sends to the requested surface even when it is not the workspace's default surface.
- Behavior for `--workspace` (pass-through) is unchanged.